### PR TITLE
ci: release to registry pipeline

### DIFF
--- a/.github/publish-on-release.yml
+++ b/.github/publish-on-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-to-vscode-marketplace:
-    name: 'Publish to VsCode MarketPlace'
+    name: 'Publish to VS Code Extension Marketplace'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/publish-on-release.yml
+++ b/.github/publish-on-release.yml
@@ -17,7 +17,7 @@ jobs:
           VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
 
   publish-to-openvsx:
-    name: 'Publish to Open VSX'
+    name: 'Publish to Open VSX Registry'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/publish-on-release.yml
+++ b/.github/publish-on-release.yml
@@ -1,0 +1,28 @@
+name: 'Publish on Release'
+on:
+  release:
+    types: ["created"]
+
+jobs:
+  publish-to-vscode-marketplace:
+    name: 'Publish to VsCode MarketPlace'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yarn
+      - uses: lannonbr/vsce-action@3.0.0
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+
+  publish-to-openvsx:
+    name: 'Publish to Open VSX'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yarn
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPENVSX_TOKEN }}


### PR DESCRIPTION
- Added a Github Workflow in order to publish new versions to `VSCode Marketplace` and `Open VSX` registries when a new release is created in Github.