### PR TITLE
feat: remove bin bash dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Allows you to use Hutte capabilities from your VSCode application, without havin
 
 ## Pre-requisites
 
-- [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)
-- [Hutte CLI](https://github.com/hutte-io/cli), check [this article](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin) for more information. Make sure the version of Hutte plugin is equal or bigger than `2.0.2`.
+- [Salesforce CLI](https://developer.salesforce.com/tools/sfdxcli)
+- [Hutte CLI](https://github.com/hutte-io/cli), check [this article](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin) for more information. Make sure the version of Hutte plugin is equal or bigger than `2.1.0`.
   - Upgrading Hutte CLI:
-    - To check the current version of Hutte plugin, use `sfdx plugins:inspect hutte`
-    - To upgrade to 2.0.2, use `sfdx plugins:install hutte@2.0.2`
+    - To check the current version of Hutte plugin, use `sf plugins inspect hutte`
+    - To upgrade to 2.1.0, use `sf plugins install hutte@2.1.0`
 - [Hutte account](https://hutte.io/trails/signup/)
 
 ## Features
@@ -32,7 +32,7 @@ Allows you to use Hutte capabilities from your VSCode application, without havin
 
 ### 1.1.0
 
-*Added compatibility with Salesforce Code Builder, Github Workspaces and Windows operative system, through the usage of the new `--org-name` flag in `sf hutte org authorize` command, which allows to remove the dependency from `bash` terminal in command execution
+*Added compatibility with Salesforce Code Builder, GitHub Workspaces and the Windows operating system, through the usage of the new `--org-name` flag in `sf hutte org authorize` command, which allows to remove the `bash` dependency in command execution
 
 ### 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Allows you to use Hutte capabilities from your VSCode application, without havin
 ## Pre-requisites
 
 - [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)
-- [Hutte CLI](https://github.com/hutte-io/cli), check [this article](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin) for more information. Make sure the version of Hutte plugin is equal or bigger than `1.1.0`.
+- [Hutte CLI](https://github.com/hutte-io/cli), check [this article](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin) for more information. Make sure the version of Hutte plugin is equal or bigger than `2.0.2`.
   - Upgrading Hutte CLI:
     - To check the current version of Hutte plugin, use `sfdx plugins:inspect hutte`
-    - To upgrade to 1.1.0, use `sfdx plugins:install hutte@1.1.0`
+    - To upgrade to 2.0.2, use `sfdx plugins:install hutte@2.0.2`
 - [Hutte account](https://hutte.io/trails/signup/)
 
 ## Features
@@ -30,9 +30,13 @@ Allows you to use Hutte capabilities from your VSCode application, without havin
 
 ## Release Notes
 
+### 1.1.0
+
+*Added compatibility with Salesforce Code Builder, Github Workspaces and Windows operative system, through the usage of the new `--org-name` flag in `sf hutte org authorize` command, which allows to remove the dependency from `bash` terminal in command execution
+
 ### 1.0.0
 
-First version of the extension
+*First version of the extension
 
 ## Feedback and Bug Reports
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
       },
       {
         "view": "hutteIncorrectCli",
-        "contents": "To use Hutte VSCode Extension, ensure the prerequisites are met:\n- [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)\n- [Hutte SFDX Plugin (minimum 1.1.0 version)](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin). If have already installed a lower version of Hutte Plugin, run 'sfdx plugins:install hutte@1.2.0' (1.2.0 or more recent version) to upgrade it.\nAfter installing the required tools, restart your VSCode instance to use the Hutte Extension."
+        "contents": "To use Hutte VSCode Extension, ensure the prerequisites are met:\n- [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)\n- [Hutte SFDX Plugin (minimum 2.0.2)](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin). If have already installed a lower version of Hutte Plugin, run 'sf plugins install hutte@2.0.2' (2.0.2 or more recent version) to upgrade it.\nAfter installing the required tools, restart your VSCode instance to use the Hutte Extension."
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
       },
       {
         "view": "hutteIncorrectCli",
-        "contents": "To use Hutte VSCode Extension, ensure the prerequisites are met:\n- [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)\n- [Hutte SFDX Plugin (minimum 2.0.2)](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin). If have already installed a lower version of Hutte Plugin, run 'sf plugins install hutte@2.0.2' (2.0.2 or more recent version) to upgrade it.\nAfter installing the required tools, restart your VSCode instance to use the Hutte Extension."
+        "contents": "To use Hutte VSCode Extension, ensure the prerequisites are met:\n- [SFDX CLI](https://developer.salesforce.com/tools/sfdxcli)\n- [Hutte SFDX Plugin (minimum 2.1.0)](https://docs.hutte.io/en/articles/6836945-hutte-sfdx-plugin). If have already installed a lower version of Hutte Plugin, run 'sf plugins install hutte@2.1.0' (2.1.0 or more recent version) to upgrade it.\nAfter installing the required tools, restart your VSCode instance to use the Hutte Extension."
       }
     ],
     "menus": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -59,10 +59,8 @@ export async function authorizeOrg(orgName?: string) {
 		title: "Hutte: Setting Org as Default & Switching to the Org's Git Branch",
 		cancellable: false
 	}, () => {
-		try {
-			// const output = commandSync(String.raw`echo -n "${orgName}" | sfdx hutte:org:authorize --no-pull`, { shell:true,  cwd: getRootPath() });
-			// TODO: Add orgName as a parameter to sfdx hutte:org:authorize in Hutte CLI and refactor this to not use a Unix Shell and therefore make it compatible with more devices.
-			const output = execSync(String.raw`echo -n "${orgName}" | sfdx hutte:org:authorize --no-pull`, { cwd: getRootPath(), shell: "/bin/bash" }).toString();
+		try {			
+			execSync(String.raw`sf hutte org authorize --no-pull --org-name ${orgName}`, { cwd: getRootPath() }).toString();
 			vscode.window.showInformationMessage('Hutte: Successfully Set Org as Default');
 		} catch (err: any) {
 			vscode.window.showErrorMessage('Hutte Error: ' + err.message);


### PR DESCRIPTION
Added compatibility with Salesforce Code Builder, Github Workspaces and Windows operative system, through the usage of the new `--org-name` flag in `sf hutte org authorize` command, which allows to remove the dependency from `bash` terminal in command execution.

IMPORTANT: Depends on https://github.com/hutte-io/cli/pull/48, first, a new version of the hutte CLI has to be created, then this VSCode extension can make use of the `--org-name` flag.