### PR TITLE
chore: configure dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+version: 2
+updates:
+  # npm/yarn dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - "dependencies"
+    groups:
+      # Group all production dependency updates together
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group all development dependency updates together
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group all TypeScript type definitions together
+      typescript-types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      # Group ESLint and TypeScript tooling
+      linting:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group testing tools
+      testing:
+        patterns:
+          - "mocha"
+          - "@vscode/test-electron"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Group all GitHub Actions updates together
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary                                                                                                                     
                                                                                                                                 
  - Configure Dependabot for npm and GitHub Actions ecosystems                                                                   
  - Set up weekly update schedule (Mondays at 09:00 UTC)                                                                         
  - Implement grouping strategy to reduce PR noise                                                                               
  - Add conventional commit prefixes for cleaner git history                                                                     
                                                                                                                                 
  ## Details                                                                                                                     
                                                                                                                                 
  This adds automated dependency management with the following configuration:                                                    
                                                                                                                                 
  **npm dependencies:**                                                                                                          
  - Groups minor/patch updates by category (production, dev, types, linting, testing)                                            
  - Major versions kept as individual PRs for careful review                                                                     
  - Limit of 10 open PRs                                                                                                         
                                                                                                                                 
  **GitHub Actions:**                                                                                                            
  - Groups all minor/patch action updates together                                                                               
  - Limit of 5 open PRs                                                                                                          
                                                                                                                                 
  **Grouping reduces noise:** Instead of receiving 10+ individual PRs per week, related updates are bundled together (e.g., all  
  `@types/*` packages in one PR, all ESLint-related packages in another).